### PR TITLE
v0.2.1

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 17, 16, 15, 14]
+        node: ['18', '17', '16', '15', '14']
     container: node:${{ matrix.node }}
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -265,10 +265,11 @@ Imglab.url(
 
 The `expires` parameter allows you to specify a UNIX timestamp in seconds after which the request is expired.
 
-In the following example we specify an expiration time of one hour from the current time:
+If a `Date` instance is used as value to `expires` parameter it will be automatically converted to UNIX timestamp. In the following example, we specify an expiration time of one hour, adding 3600 seconds to the current time:
 
 ```javascript
-const expires = Math.floor(Date.now() / 1000) + 3600
+// Date object uses milliseconds internally so we need to multiply 3600 by 1000
+const expires = Date.now() + (3600 * 1000)
 
 Imglab.url('assets', 'image.jpeg', { width: 500, expires: expires })
 ```

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ If a `Date` instance is used as value to `expires` parameter it will be automati
 
 ```javascript
 // Date object uses milliseconds internally so we need to multiply 3600 by 1000
-const expires = Date.now() + (3600 * 1000)
+var expires = new Date(Date.now() + (3600 * 1000))
 
 Imglab.url('assets', 'image.jpeg', { width: 500, expires: expires })
 ```

--- a/README.md
+++ b/README.md
@@ -261,6 +261,20 @@ Imglab.url(
 
 `signature` query parameter will be automatically generated and attached to the nested URL value.
 
+### Specifying URLs with expiration timestamp
+
+The `expires` parameter allows you to specify a UNIX timestamp in seconds after which the request is expired.
+
+In the following example we specify an expiration time of one hour from the current time:
+
+```javascript
+const expires = Math.floor(Date.now() / 1000) + 3600
+
+Imglab.url('assets', 'image.jpeg', { width: 500, expires: expires })
+```
+
+> Note: The `expires` parameter should be used in conjunction with secure sources. Otherwise, `expires` value could be tampered with.
+
 ## Generating URLs for on-premises imglab server
 
 For on-premises imglab server is possible to define custom sources pointing to your server location.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imglab/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@imglab/core",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@imglab/core",
   "source": "src/index.js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Official imglab Javascript library",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,9 +10,8 @@ export default class Utils {
   }
 
   static normalizeParams(params) {
-    return Object.keys(params).reduce((result, key) => {
-      result[Utils.#normalizeKey(key)] = params[key]
-      return result
+    return Object.entries(params).reduce((result, [key, value]) => {
+      return Object.assign(result, Utils.#normalizeParam(Utils.#normalizeKey(key), value))
     }, {})
   }
 
@@ -28,5 +27,14 @@ export default class Utils {
 
   static #normalizeKey(key) {
     return key.replace(Utils.#NORMALIZE_KEY_REGEXP, '$1-$2').replace('_', '-').toLowerCase()
+  }
+
+  static #normalizeParam(key, value) {
+    switch(true) {
+      case key === 'expires' && value instanceof Date:
+        return { [key]: Math.floor(value / 1000) }
+      default:
+        return { [key]: value }
+    }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,8 +10,8 @@ export default class Utils {
   }
 
   static normalizeParams(params) {
-    return Object.entries(params).reduce((result, [key, value]) => {
-      return Object.assign(result, Utils.#normalizeParam(Utils.#normalizeKey(key), value))
+    return Object.entries(params).reduce((normalizedParams, [key, value]) => {
+      return Object.assign(normalizedParams, Utils.#normalizeParam(Utils.#normalizeKey(key), value))
     }, {})
   }
 

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -133,6 +133,12 @@ describe('Url', () => {
       expect(url).toBe('https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange')
     })
 
+    it('returns url with expires param using a Date instance', () => {
+      const url = Url.url('assets', 'example.jpeg', { width: 200, height: 300, expires: new Date(1464096368 * 1000) })
+
+      expect(url).toBe('https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&expires=1464096368')
+    })
+
     it('returns url with path starting with slash', () => {
       const url = Url.url('assets', '/example.jpeg', { width: 200, height: 300, format: 'png' })
 
@@ -297,6 +303,12 @@ describe('Url', () => {
       const url = Url.url(new Source('assets'), 'example.jpeg', { trim: 'color', 'trim-color': 'orange' })
 
       expect(url).toBe('https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange')
+    })
+
+    it('returns url with expires param using a Date instance', () => {
+      const url = Url.url(new Source('assets'), 'example.jpeg', { width: 200, height: 300, expires: new Date(1464096368 * 1000) })
+
+      expect(url).toBe('https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&expires=1464096368')
     })
 
     it('returns url with disabled subdomains', () => {
@@ -660,6 +672,20 @@ describe('Url', () => {
       )
 
       expect(url).toBe('https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw')
+    })
+
+    it('returns url with expires param using a Date instance', () => {
+      const url = Url.url(
+        new Source('assets', { secureKey: SECURE_KEY, secureSalt: SECURE_SALT }),
+        'example.jpeg',
+        {
+          width: 200,
+          height: 300,
+          expires: new Date(1464096368 * 1000)
+        }
+      )
+
+      expect(url).toBe('https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&expires=1464096368&signature=DpkRMiecDlOaQAQM5IQ8Cd4ek8nGvfPxV6XmCN0GbAU')
     })
 
     it('returns url with disabled subdomains', () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -28,6 +28,9 @@ describe('Utils', () => {
       expect(Utils.normalizeParams({ trim: 'color', 'trim-color': 'orange' })).toEqual({ trim: 'color', 'trim-color': 'orange' })
       expect(Utils.normalizeParams({ trim: 'color', trim_color: 'orange' })).toEqual({ trim: 'color', 'trim-color': 'orange' })
       expect(Utils.normalizeParams({ trim: 'color', trimColor: 'orange' })).toEqual({ trim: 'color', 'trim-color': 'orange' })
+      expect(Utils.normalizeParams({ width: 200, expires: 1464096368 })).toEqual({ width: 200, expires: 1464096368 })
+      expect(Utils.normalizeParams({ width: 200, expires: '1464096368' })).toEqual({ width: 200, expires: '1464096368' })
+      expect(Utils.normalizeParams({ width: 200, expires: new Date(1464096368 * 1000)})).toEqual({ width: 200, expires: 1464096368 })
     })
   })
 


### PR DESCRIPTION
* Fix Node workflow matrix versions.
* Normalize `Date` instances when found as value on `expires` parameter to UNIX timestamp.
* Add README section about URLs with expiration timestamp.